### PR TITLE
5.x compat and upgrade dogstatsd-ruby

### DIFF
--- a/lib/logstash/outputs/dogstatsd.rb
+++ b/lib/logstash/outputs/dogstatsd.rb
@@ -1,16 +1,7 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
-
-# This is a hack to load the dogstatsd-ruby gem's statsd.rb file into a
-# namespace so as to not clobber the top-level Statsd provided by the
-# much-more-popular Statsd gem. The problem is that both gems have a file named
-# 'statsd.rb' that you are supposed to load. Why did Datadog not name their file
-# differently? Who knows!
-# (see: https://github.com/DataDog/dogstatsd-ruby/pull/3)
-module Datadog
-  module_eval(File.read(Gem.find_files('**/statsd.rb').grep(/dogstatsd/).first))
-end
+require "datadog/statsd"
 
 # dogstatsd is a fork of the statsd protocol which aggregates statistics, such
 # as counters and timers, and ships them over UDP to the dogstatsd-server

--- a/logstash-output-dogstatsd.gemspec
+++ b/logstash-output-dogstatsd.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-dogstatsd'
-  s.version         = '2.0.0'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send metrics to StatsD"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-input-generator'
 
   # This version is pinned exactly to ensure that upgrades don't break the

--- a/logstash-output-dogstatsd.gemspec
+++ b/logstash-output-dogstatsd.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-dogstatsd'
-  s.version         = '3.0.0'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send metrics to StatsD"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-dogstatsd.gemspec
+++ b/logstash-output-dogstatsd.gemspec
@@ -22,10 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-input-generator'
-
-  # This version is pinned exactly to ensure that upgrades don't break the
-  # gnarly `module_eval` hack in lib/logstash/outputs/dogstatsd.rb.
-  s.add_runtime_dependency 'dogstatsd-ruby', '= 1.6'
+  s.add_runtime_dependency 'dogstatsd-ruby', '= 2.2'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'overcommit'


### PR DESCRIPTION
Make this plugin compatible with logstash 5.x
Also upgraded `dogstasd-ruby` to 2.2